### PR TITLE
[ADD] property last to navigation path to observe the newest incoming path

### DIFF
--- a/Sources/NavigationBackport/NBNavigationPath.swift
+++ b/Sources/NavigationBackport/NBNavigationPath.swift
@@ -7,6 +7,7 @@ public struct NBNavigationPath {
 
   public var count: Int { elements.count }
   public var isEmpty: Bool { elements.isEmpty }
+  public var last: AnyHashable? { elements.last }
 
   public init(_ elements: [AnyHashable] = []) {
     self.elements = elements


### PR DESCRIPTION
I need a possibility to observe the last incoming value to a path. My first imagination: "NBNavigationPath based on elements. Nice, then I can use the array functionality." Then I found out, that the `elements` property is internal. That's the reason, why I need this property getter.