### PR TITLE
Introduce NBNavigationSplitView as a backport of NavigationSplitView

### DIFF
--- a/NavigationBackportApp/NavigationBackportApp.xcodeproj/project.pbxproj
+++ b/NavigationBackportApp/NavigationBackportApp.xcodeproj/project.pbxproj
@@ -13,13 +13,14 @@
 		52925EC228549A62001B9190 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52925EB028549A60001B9190 /* ContentView.swift */; };
 		52925EC328549A62001B9190 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52925EB128549A62001B9190 /* Assets.xcassets */; };
 		52925EC428549A62001B9190 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52925EB128549A62001B9190 /* Assets.xcassets */; };
-		52925ECF28549A84001B9190 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 52925ECE28549A84001B9190 /* NavigationBackport */; };
 		529673CE286BB44400C01BCF /* NBNavigationPathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673CD286BB44400C01BCF /* NBNavigationPathView.swift */; };
 		529673CF286BB44400C01BCF /* NBNavigationPathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673CD286BB44400C01BCF /* NBNavigationPathView.swift */; };
 		529673D1286BB50200C01BCF /* ArrayBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D0286BB50200C01BCF /* ArrayBindingView.swift */; };
 		529673D2286BB50200C01BCF /* ArrayBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D0286BB50200C01BCF /* ArrayBindingView.swift */; };
 		529673D4286BC48600C01BCF /* NoBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D3286BC48600C01BCF /* NoBindingView.swift */; };
 		529673D5286BC48600C01BCF /* NoBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D3286BC48600C01BCF /* NoBindingView.swift */; };
+		5A70FAF42886436C001F26D1 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 5A70FAF32886436C001F26D1 /* NavigationBackport */; };
+		5A70FAF628864370001F26D1 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 5A70FAF528864370001F26D1 /* NavigationBackport */; };
 		5ABA56EB288282C500178824 /* SplitDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E8288282C400178824 /* SplitDemo.swift */; };
 		5ABA56EC288282C500178824 /* SplitDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E8288282C400178824 /* SplitDemo.swift */; };
 		5ABA56ED288282C500178824 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E9288282C500178824 /* DetailView.swift */; };
@@ -49,7 +50,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52925ECF28549A84001B9190 /* NavigationBackport in Frameworks */,
+				5A70FAF42886436C001F26D1 /* NavigationBackport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,6 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A70FAF628864370001F26D1 /* NavigationBackport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,6 +72,7 @@
 				52925EAE28549A60001B9190 /* Shared */,
 				52925EBD28549A62001B9190 /* macOS */,
 				52925EB728549A62001B9190 /* Products */,
+				5A70FAF22886436C001F26D1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -114,6 +117,13 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		5A70FAF22886436C001F26D1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -131,7 +141,7 @@
 			);
 			name = "NavigationBackportApp (iOS)";
 			packageProductDependencies = (
-				52925ECE28549A84001B9190 /* NavigationBackport */,
+				5A70FAF32886436C001F26D1 /* NavigationBackport */,
 			);
 			productName = "NavigationBackportApp (iOS)";
 			productReference = 52925EB628549A62001B9190 /* NavigationBackportApp.app */;
@@ -150,6 +160,9 @@
 			dependencies = (
 			);
 			name = "NavigationBackportApp (macOS)";
+			packageProductDependencies = (
+				5A70FAF528864370001F26D1 /* NavigationBackport */,
+			);
 			productName = "NavigationBackportApp (macOS)";
 			productReference = 52925EBC28549A62001B9190 /* NavigationBackportApp.app */;
 			productType = "com.apple.product-type.application";
@@ -182,7 +195,6 @@
 			);
 			mainGroup = 52925EA928549A60001B9190;
 			packageReferences = (
-				52925ECD28549A84001B9190 /* XCRemoteSwiftPackageReference "NavigationBackport" */,
 			);
 			productRefGroup = 52925EB728549A62001B9190 /* Products */;
 			projectDirPath = "";
@@ -507,21 +519,13 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		52925ECD28549A84001B9190 /* XCRemoteSwiftPackageReference "NavigationBackport" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/johnpatrickmorgan/NavigationBackport";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		52925ECE28549A84001B9190 /* NavigationBackport */ = {
+		5A70FAF32886436C001F26D1 /* NavigationBackport */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 52925ECD28549A84001B9190 /* XCRemoteSwiftPackageReference "NavigationBackport" */;
+			productName = NavigationBackport;
+		};
+		5A70FAF528864370001F26D1 /* NavigationBackport */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = NavigationBackport;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/NavigationBackportApp/NavigationBackportApp.xcodeproj/project.pbxproj
+++ b/NavigationBackportApp/NavigationBackportApp.xcodeproj/project.pbxproj
@@ -20,6 +20,12 @@
 		529673D2286BB50200C01BCF /* ArrayBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D0286BB50200C01BCF /* ArrayBindingView.swift */; };
 		529673D4286BC48600C01BCF /* NoBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D3286BC48600C01BCF /* NoBindingView.swift */; };
 		529673D5286BC48600C01BCF /* NoBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D3286BC48600C01BCF /* NoBindingView.swift */; };
+		5ABA56EB288282C500178824 /* SplitDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E8288282C400178824 /* SplitDemo.swift */; };
+		5ABA56EC288282C500178824 /* SplitDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E8288282C400178824 /* SplitDemo.swift */; };
+		5ABA56ED288282C500178824 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E9288282C500178824 /* DetailView.swift */; };
+		5ABA56EE288282C500178824 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E9288282C500178824 /* DetailView.swift */; };
+		5ABA56EF288282C500178824 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56EA288282C500178824 /* SidebarView.swift */; };
+		5ABA56F0288282C500178824 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56EA288282C500178824 /* SidebarView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +39,9 @@
 		529673CD286BB44400C01BCF /* NBNavigationPathView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NBNavigationPathView.swift; sourceTree = "<group>"; };
 		529673D0286BB50200C01BCF /* ArrayBindingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayBindingView.swift; sourceTree = "<group>"; };
 		529673D3286BC48600C01BCF /* NoBindingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoBindingView.swift; sourceTree = "<group>"; };
+		5ABA56E8288282C400178824 /* SplitDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplitDemo.swift; sourceTree = "<group>"; };
+		5ABA56E9288282C500178824 /* DetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		5ABA56EA288282C500178824 /* SidebarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +76,9 @@
 		52925EAE28549A60001B9190 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				5ABA56E9288282C500178824 /* DetailView.swift */,
+				5ABA56EA288282C500178824 /* SidebarView.swift */,
+				5ABA56E8288282C400178824 /* SplitDemo.swift */,
 				52925EAF28549A60001B9190 /* NavigationBackportApp.swift */,
 				52925EB028549A60001B9190 /* ContentView.swift */,
 				529673D0286BB50200C01BCF /* ArrayBindingView.swift */,
@@ -207,7 +219,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				529673CE286BB44400C01BCF /* NBNavigationPathView.swift in Sources */,
+				5ABA56EF288282C500178824 /* SidebarView.swift in Sources */,
+				5ABA56EB288282C500178824 /* SplitDemo.swift in Sources */,
 				529673D1286BB50200C01BCF /* ArrayBindingView.swift in Sources */,
+				5ABA56ED288282C500178824 /* DetailView.swift in Sources */,
 				529673D4286BC48600C01BCF /* NoBindingView.swift in Sources */,
 				52925EC128549A62001B9190 /* ContentView.swift in Sources */,
 				52925EBF28549A62001B9190 /* NavigationBackportApp.swift in Sources */,
@@ -219,7 +234,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				529673CF286BB44400C01BCF /* NBNavigationPathView.swift in Sources */,
+				5ABA56F0288282C500178824 /* SidebarView.swift in Sources */,
+				5ABA56EC288282C500178824 /* SplitDemo.swift in Sources */,
 				529673D2286BB50200C01BCF /* ArrayBindingView.swift in Sources */,
+				5ABA56EE288282C500178824 /* DetailView.swift in Sources */,
 				529673D5286BC48600C01BCF /* NoBindingView.swift in Sources */,
 				52925EC228549A62001B9190 /* ContentView.swift in Sources */,
 				52925EC028549A62001B9190 /* NavigationBackportApp.swift in Sources */,

--- a/NavigationBackportApp/Shared/ContentView.swift
+++ b/NavigationBackportApp/Shared/ContentView.swift
@@ -19,6 +19,10 @@ struct ContentView: View {
         .tabItem { Text("ArrayBinding") }
       NoBindingView()
         .tabItem { Text("NoBinding") }
+      if UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.userInterfaceIdiom == .mac {
+        SplitDemo()
+          .tabItem { Text("SplitDemo") }
+      }
     }
   }
 }

--- a/NavigationBackportApp/Shared/DetailView.swift
+++ b/NavigationBackportApp/Shared/DetailView.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import NavigationBackport
 
 struct DetailView: View {
     
@@ -9,9 +10,20 @@ struct DetailView: View {
     if let selectedRoute = selectedRoute {
       switch selectedRoute {
       case .numbers:
-        ArrayBindingView()
+        List {
+          ForEach(0..<100) { num in
+            NBNavigationLink(value: num) {
+              Text(num.description)
+            }
+          }
+        }
+        .nbNavigationDestination(for: Int.self) { num in
+          Text(num.description)
+        }
+        .navigationTitle("Numbers")
       case .text:
         Text("Hello World")
+          .navigationTitle("Text")
       }
     } else {
       EmptyView()

--- a/NavigationBackportApp/Shared/DetailView.swift
+++ b/NavigationBackportApp/Shared/DetailView.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftUI
+
+struct DetailView: View {
+    
+  @Binding var selectedRoute: SidebarRouter?
+    
+  var body: some View {
+    if let selectedRoute = selectedRoute {
+      switch selectedRoute {
+      case .numbers:
+        ArrayBindingView()
+      case .text:
+        Text("Hello World")
+      }
+    } else {
+      EmptyView()
+    }
+  }
+}

--- a/NavigationBackportApp/Shared/SidebarView.swift
+++ b/NavigationBackportApp/Shared/SidebarView.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftUI
+
+enum SidebarRouter: String, Hashable, CaseIterable {
+    
+  case numbers
+  case text
+}
+
+struct SidebarView: View {
+    
+  @Binding var selectedRouter: SidebarRouter?
+    
+  var body: some View {
+    if #available(iOS 16.0, *) {
+      List(selection: $selectedRouter) {
+        ForEach(SidebarRouter.allCases, id: \.self) { route in
+          Text(route.rawValue)
+        }
+      }
+    } else {
+      List(selection: $selectedRouter) {
+        ForEach(SidebarRouter.allCases, id: \.self) { route in
+          Button {
+            selectedRouter = route
+          } label: {
+            HStack {
+              Text(route.rawValue)
+              Spacer()
+            }
+            .padding()
+            .background(route == selectedRouter ? Color.gray.opacity(0.5) : Color.clear)
+            .cornerRadius(10)
+            .contentShape(Rectangle())
+          }
+        }
+        .buttonStyle(.plain)
+      }
+    }
+  }
+}

--- a/NavigationBackportApp/Shared/SplitDemo.swift
+++ b/NavigationBackportApp/Shared/SplitDemo.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftUI
+import NavigationBackport
+
+struct SplitDemo: View {
+    
+  @State var selectedRouter: SidebarRouter? = .numbers
+    
+  var body: some View {
+    NBNavigationSplitView {
+      SidebarView(selectedRouter: $selectedRouter)
+    } detail: {
+      DetailView(selectedRoute: $selectedRouter)
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This package uses the navigation APIs available in older SwiftUI versions (such 
  
 ✅ `NavigationStack` -> `NBNavigationStack`
 
+✳️ `NavigationSplitView` -> `NBNavigationSplitView` (Only support double column style by now)
+
 ✅ `NavigationLink` -> `NBNavigationLink`
 
 ✅ `NavigationPath` -> `NBNavigationPath`

--- a/Sources/NavigationBackport/NBNavigationSplitView.swift
+++ b/Sources/NavigationBackport/NBNavigationSplitView.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftUI
+
+@available(iOS, deprecated: 16.0, message: "Use SwiftUI's Navigation API beyond iOS 15")
+public struct NBNavigationSplitView<Sidebar: View, Detail: View, Data: Hashable>: View {
+  @Binding var path: [Data]
+  @ObservedObject var pathHolder: PathHolder<Data>
+
+  let sideBar: Sidebar
+  let detail: Detail
+
+  var erasedPath: Binding<[AnyHashable]> {
+    Binding(
+      get: { path.map(AnyHashable.init) },
+      set: { newValue in
+        path = newValue.map { anyHashable in
+          guard let data = anyHashable.base as? Data else {
+            fatalError("Cannot add \(type(of: anyHashable.base)) to stack of \(Data.self)")
+          }
+          return data
+        }
+      }
+    )
+  }
+
+  @StateObject var destinationBuilder = DestinationBuilderHolder()
+
+  public var body: some View {
+    NavigationView {
+      sideBar
+      Router(rootView: detail, screens: $path)
+        .environmentObject(NavigationPathHolder(erasedPath))
+        .environmentObject(destinationBuilder)
+    }.navigationViewStyle(DoubleColumnNavigationViewStyle())
+  }
+
+  init(path: Binding<[Data]>, pathHolder: PathHolder<Data>, @ViewBuilder sideBar: () -> Sidebar, @ViewBuilder detail: () -> Detail) {
+    _path = path
+    self.sideBar = sideBar()
+    self.detail = detail()
+    self.pathHolder = pathHolder
+  }
+
+  public init(path: Binding<[Data]>, @ViewBuilder sideBar: () -> Sidebar, @ViewBuilder detail: () -> Detail) {
+    self.init(path: path, pathHolder: .init(), sideBar: sideBar, detail: detail)
+  }
+}
+
+public extension NBNavigationSplitView where Data == AnyHashable {
+  init(@ViewBuilder sideBar: () -> Sidebar, @ViewBuilder detail: () -> Detail) {
+    let pathHolder = PathHolder<Data>()
+    let path = Binding(
+      get: { pathHolder.path },
+      set: { pathHolder.path = $0 }
+    )
+    self.init(path: path, pathHolder: pathHolder, sideBar: sideBar, detail: detail)
+  }
+}
+
+public extension NBNavigationSplitView where Data == AnyHashable {
+  init(path: Binding<NBNavigationPath>, @ViewBuilder sideBar: () -> Sidebar, @ViewBuilder detail: () -> Detail) {
+    let path = Binding(
+      get: { path.wrappedValue.elements },
+      set: { path.wrappedValue.elements = $0 }
+    )
+    self.init(path: path, sideBar: sideBar, detail: detail)
+  }
+}


### PR DESCRIPTION
Apple introduced `NavigationSplitView` in WWDC22, this is a backport implementation of it with limitation:
- only support double colunm layout (sidebar + detail)
- can not nested in NBNavigationStack

Pease see the demo for usage