### PR TITLE
public NavigationPathHolder for usage in cases where Custom UI is needed

### DIFF
--- a/Sources/NavigationBackport/NavigationPathHolder.swift
+++ b/Sources/NavigationBackport/NavigationPathHolder.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SwiftUI
 
-class NavigationPathHolder: ObservableObject {
-  var path: Binding<[AnyHashable]>
+public class NavigationPathHolder: ObservableObject {
+  public var path: Binding<[AnyHashable]>
 
-  init(_ path: Binding<[AnyHashable]>) {
+  public init(_ path: Binding<[AnyHashable]>) {
     self.path = path
   }
 }


### PR DESCRIPTION
When using a SwiftUI Button or any other programmatic way, it might be convinient to be able to access the **NavigationPathHolder** EnvironmentObject to manipulate the path directly in sub views.
