### PR TITLE
Adds NBNavigationLinkViewModifier to allow programmatic triggering of the navigate action.

### DIFF
--- a/Sources/NavigationBackport/NBNavigationLinkViewModifier.swift
+++ b/Sources/NavigationBackport/NBNavigationLinkViewModifier.swift
@@ -1,0 +1,24 @@
+import Combine
+import Foundation
+import SwiftUI
+
+@available(iOS, deprecated: 16.0, message: "Use SwiftUI's Navigation API beyond iOS 15")
+public struct NBNavigationLinkViewModifier<P: Hashable>: ViewModifier {
+  @Binding var value: P?
+
+  @EnvironmentObject var pathHolder: NavigationPathHolder
+
+  public func body(content: Content) -> some View {
+    content
+      .onChange(of: Just(value)) { _ in
+          guard let value = value else { return }
+          pathHolder.path.wrappedValue.append(value)
+      }
+  }
+}
+
+public extension View {
+  func nbNavigationLink<P: Hashable>(value: Binding<P?>) -> some View {
+    modifier(NBNavigationLinkViewModifier(value: value))
+  }
+}


### PR DESCRIPTION
## Purpose

In use cases where we would normally like to use the `NBNavigationLink`, but need to trigger the same navigation action programmatically, based on a changing state variable, instead of with a button press.

E.g. I found this useful for a few cases where there is an HTML web view embedded in app, and I needed to intercept links being tapped, to trigger onward navigation.