### PR TITLE
Adds Navigator and navigation utilities

### DIFF
--- a/NavigationBackportApp/Shared/NoBindingView.swift
+++ b/NavigationBackportApp/Shared/NoBindingView.swift
@@ -20,11 +20,20 @@ struct NoBindingView: View {
 }
 
 private struct HomeView: View {
+  @EnvironmentObject var navigator: PathNavigator
 
   var body: some View {
     VStack(spacing: 8) {
       NBNavigationLink(value: NumberList(range: 0 ..< 100), label: { Text("Pick a number") })
+      Button("99 Red balloons", action: show99RedBalloons)
     }.navigationTitle("Home")
+  }
+  
+  func show99RedBalloons() {
+    navigator.withDelaysIfUnsupported {
+      $0.append(99)
+      $0.append(EmojiVisualisation(emoji: "🎈", count: 99))
+    }
   }
 }
 
@@ -40,6 +49,7 @@ private struct NumberListView: View {
 }
 
 private struct NumberView: View {
+  @EnvironmentObject var navigator: PathNavigator
   @State var number: Int
 
   var body: some View {
@@ -58,6 +68,9 @@ private struct NumberView: View {
         value: EmojiVisualisation(emoji: "🐑", count: number),
         label: { Text("Visualise with sheep") }
       )
+      Button("Pop to root") {
+        navigator.popToRoot()
+      }
     }.navigationTitle("\(number)")
   }
 }

--- a/README.md
+++ b/README.md
@@ -101,8 +101,40 @@ struct EmojiView: View {
   }
 }
 ```
- 
- ## Deep-linking
+
+## Additional features
+
+As well as replicating the standard features of the new `NavigationStack` APIs, some helpful utilities have also been added. 
+
+### Navigator
+
+A `Navigator` object is available through the environment, giving access to the current navigation path. The navigator can be accessed via the environment, e.g. for a NBNavigationPath-backed stack:
+
+```swift
+@EnvironmentObject var navigator: PathNavigator
+```
+
+Or for a stack backed by an Array, e.g. `[ScreenType]`:
+
+```swift
+@EnvironmentObject var navigator: Navigator<ScreenType>
+```
+
+### Navigation functions
+
+Whether interacting with an `Array`, an `NBNavigationPath`, or a `Navigator`, a number of utility functions are available for easier navigation, such as:
+
+```swift
+path.push(Profile(name: "John"))
+
+path.pop()
+
+path.popToRoot()
+
+path.popTo(Profile.self)
+```
+
+## Deep-linking
  
  Before `NavigationStack`, SwiftUI did not support pushing more than one screen in a single state update, e.g. when deep-linking to a screen multiple layers deep in a navigation hierarchy. `NavigationBackport` provides an API to work around this limitation: you can wrap such path changes within a call to `withDelaysIfUnsupported`, and the library will, if necessary, break down the larger update into a series of smaller updates that SwiftUI supports, with delays in between. For example, the following code that tries to push three screens in one update will not work:
 

--- a/Sources/NavigationBackport/Array+utilities.swift
+++ b/Sources/NavigationBackport/Array+utilities.swift
@@ -31,10 +31,10 @@ public extension Array where Element: NBScreen {
     pop(popCount)
   }
 
-  /// Pops to the root screen (index 0). The resulting screen count
-  /// will be 0.
+  /// Pops to the root screen. The resulting screen count will be 0.
   mutating func popToRoot() {
-    popTo(index: 0)
+    // Popping to index -1 ensures the resulting array is empty.
+    popTo(index: -1)
   }
 
   /// Pops to the topmost (most recently pushed) screen in the stack

--- a/Sources/NavigationBackport/Array+utilities.swift
+++ b/Sources/NavigationBackport/Array+utilities.swift
@@ -27,7 +27,7 @@ public extension Array where Element: NBScreen {
   /// will be index.
   /// - Parameter index: The index that should become the Array's endIndex.
   mutating func popTo(index: Int) {
-    let popCount = count - index
+    let popCount = count - 1 - index
     pop(popCount)
   }
 

--- a/Sources/NavigationBackport/Array+utilities.swift
+++ b/Sources/NavigationBackport/Array+utilities.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Various utilities for pushing and popping.
+public extension Array where Element: NBScreen {
+  /// Pushes a new screen.
+  /// - Parameter screen: The screen to push.
+  mutating func push(_ screen: Element) {
+    append(screen)
+  }
+
+  /// Pops a given number of screens off the stack.
+  /// - Parameter count: The number of screens to pop. Defaults to 1.
+  mutating func pop(_ count: Int = 1) {
+    assert(
+      self.count - count >= 0,
+      "Can't pop\(count == 1 ? "" : " \(count) screens") - the screen count is \(self.count)"
+    )
+    assert(
+      count >= 0,
+      "Can't pop \(count) screens - count must be positive"
+    )
+    guard self.count - count >= 0, count >= 0 else { return }
+    removeLast(count)
+  }
+
+  /// Pops to a given index in the array of screens. The resulting screen count
+  /// will be index.
+  /// - Parameter index: The index that should become the Array's endIndex.
+  mutating func popTo(index: Int) {
+    let popCount = count - index
+    pop(popCount)
+  }
+
+  /// Pops to the root screen (index 0). The resulting screen count
+  /// will be 0.
+  mutating func popToRoot() {
+    popTo(index: 0)
+  }
+
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// that satisfies the given condition. If no screens satisfy the condition,
+  /// the screens array will be unchanged.
+  /// - Parameter condition: The predicate indicating which screen to pop to.
+  /// - Returns: A `Bool` indicating whether a screen was found.
+  @discardableResult
+  mutating func popTo(where condition: (Element) -> Bool) -> Bool {
+    guard let index = lastIndex(where: condition) else {
+      return false
+    }
+    popTo(index: index)
+    return true
+  }
+}
+
+public extension Array where Element: NBScreen & Equatable {
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// equal to the given screen. If no screens are found,
+  /// the screens array will be unchanged.
+  /// - Parameter screen: The predicate indicating which screen to go back to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  mutating func popTo(_ screen: Element) -> Bool {
+    popTo(where: { $0 == screen })
+  }
+}
+
+public extension Array where Element: NBScreen & Identifiable {
+  /// Pops to the topmost (most recently pushed) identifiable screen in the stack
+  /// with the given ID. If no screens are found, the screens array will be unchanged.
+  /// - Parameter id: The id of the screen to goBack to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  mutating func popTo(id: Element.ID) -> Bool {
+    popTo(where: { $0.id == id })
+  }
+}

--- a/Sources/NavigationBackport/Binding+withDelaysIfUnsupported.swift
+++ b/Sources/NavigationBackport/Binding+withDelaysIfUnsupported.swift
@@ -2,6 +2,9 @@ import Foundation
 import SwiftUI
 
 public extension Binding where Value: Collection {
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
   @_disfavoredOverload
   func withDelaysIfUnsupported<Screen>(_ transform: (inout [Screen]) -> Void, onCompletion: (() -> Void)? = nil) where Value == [Screen] {
     let start = wrappedValue
@@ -12,7 +15,10 @@ public extension Binding where Value: Collection {
     }
   }
 
-  func withDelaysIfUnsupported<Screen>(_ transform: (inout Value) -> Void) async where Value == [Screen] {
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
+  func withDelaysIfUnsupported<Screen>(_ transform: (inout [Screen]) -> Void) async where Value == [Screen] {
     let start = wrappedValue
     let end = apply(transform, to: start)
     await withDelaysIfUnsupported(from: start, to: end, keyPath: \.self)
@@ -20,6 +26,9 @@ public extension Binding where Value: Collection {
 }
 
 public extension Binding where Value == NBNavigationPath {
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
   @_disfavoredOverload
   func withDelaysIfUnsupported(_ transform: (inout NBNavigationPath) -> Void, onCompletion: (() -> Void)? = nil) {
     let start = wrappedValue
@@ -30,6 +39,9 @@ public extension Binding where Value == NBNavigationPath {
     }
   }
 
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
   func withDelaysIfUnsupported(_ transform: (inout Value) -> Void) async {
     let start = wrappedValue
     let end = apply(transform, to: start)
@@ -38,12 +50,6 @@ public extension Binding where Value == NBNavigationPath {
 }
 
 extension Binding {
-  func withDelaysIfUnsupported<Screen>(_ transform: (inout [Screen]) -> Void, keyPath: WritableKeyPath<Value, [Screen]>) async {
-    let start = wrappedValue[keyPath: keyPath]
-    let end = apply(transform, to: start)
-    await withDelaysIfUnsupported(from: start, to: end, keyPath: keyPath)
-  }
-
   func withDelaysIfUnsupported<Screen>(from start: [Screen], to end: [Screen], keyPath: WritableKeyPath<Value, [Screen]>) async {
     let steps = NavigationBackport.calculateSteps(from: start, to: end)
 
@@ -62,10 +68,4 @@ extension Binding {
       await scheduleRemainingSteps(steps: Array(steps.dropFirst()), keyPath: keyPath)
     } catch {}
   }
-}
-
-func apply<T>(_ transform: (inout T) -> Void, to input: T) -> T {
-  var transformed = input
-  transform(&transformed)
-  return transformed
 }

--- a/Sources/NavigationBackport/CodableRepresentation.swift
+++ b/Sources/NavigationBackport/CodableRepresentation.swift
@@ -4,10 +4,10 @@ public extension NBNavigationPath {
   struct CodableRepresentation {
     static let encoder = JSONEncoder()
     static let decoder = JSONDecoder()
-    
+
     var elements: [Codable]
   }
-  
+
   var codable: CodableRepresentation? {
     if #available(iOS 14.0, *) {
       let codableElements = elements.compactMap { $0 as? Codable }
@@ -20,7 +20,7 @@ public extension NBNavigationPath {
       return nil
     }
   }
-  
+
   init(_ codable: CodableRepresentation) {
     // NOTE: Casting to Any first prevents the compiler from flagging the cast to AnyHashable as one that
     // always fails (which it isn't, thanks to the compiler magic around AnyHashable).
@@ -38,9 +38,9 @@ extension NBNavigationPath.CodableRepresentation: Encodable {
     func encodeOpened<A: Encodable>(_ element: A) throws -> Data {
       try NBNavigationPath.CodableRepresentation.encoder.encode(element)
     }
-    return try _openExistential(element, do: encodeOpened(_: ))
+    return try _openExistential(element, do: encodeOpened(_:))
   }
-  
+
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     for element in elements.reversed() {
@@ -71,7 +71,7 @@ extension NBNavigationPath.CodableRepresentation: Encodable {
 extension NBNavigationPath.CodableRepresentation: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
-    self.elements = []
+    elements = []
     while !container.isAtEnd {
       let typeName = try container.decode(String.self)
       guard let type = _typeByName(typeName) else {
@@ -90,7 +90,7 @@ extension NBNavigationPath.CodableRepresentation: Decodable {
       let data = Data(encodedValue.utf8)
       #if swift(<5.7)
         func decodeExistential(type: Codable.Type) throws -> Codable {
-          func decodeOpened<A: Codable>(type: A.Type) throws -> A {
+          func decodeOpened<A: Codable>(type _: A.Type) throws -> A {
             try NBNavigationPath.CodableRepresentation.decoder.decode(A.self, from: data)
           }
           return try _openExistential(type, do: decodeOpened)
@@ -99,13 +99,12 @@ extension NBNavigationPath.CodableRepresentation: Decodable {
       #else
         let value = try Self.decoder.decode(codableType, from: data)
       #endif
-      self.elements.insert(value, at: 0)
+      elements.insert(value, at: 0)
     }
   }
 }
 
 extension NBNavigationPath.CodableRepresentation: Equatable {
-
   public static func == (lhs: Self, rhs: Self) -> Bool {
     do {
       let encodedLhs = try encodeExistential(lhs)

--- a/Sources/NavigationBackport/DestinationBuilderModifier.swift
+++ b/Sources/NavigationBackport/DestinationBuilderModifier.swift
@@ -8,7 +8,7 @@ struct DestinationBuilderModifier<TypedData>: ViewModifier {
 
   func body(content: Content) -> some View {
     destinationBuilder.appendBuilder(typedDestinationBuilder)
-    
+
     return content
       .environmentObject(destinationBuilder)
   }

--- a/Sources/NavigationBackport/NBNavigationPath+utilities.swift
+++ b/Sources/NavigationBackport/NBNavigationPath+utilities.swift
@@ -47,4 +47,13 @@ public extension NBNavigationPath {
   mutating func popTo(_ screen: AnyHashable) -> Bool {
     return elements.popTo(screen)
   }
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// equal to the given screen. If no screens are found,
+  /// the screens array will be unchanged.
+  /// - Parameter screen: The predicate indicating which screen to go back to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  mutating func popTo<T: Hashable>(_ screenType: T.Type) -> Bool {
+    return popTo(where: { $0 is T })
+  }
 }

--- a/Sources/NavigationBackport/NBNavigationPath+utilities.swift
+++ b/Sources/NavigationBackport/NBNavigationPath+utilities.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public extension NBNavigationPath {
+  /// Pushes a new screen via a push navigation.
+  /// - Parameter screen: The screen to push.
+  mutating func push(_ screen: AnyHashable) {
+    elements.push(screen)
+  }
+  
+  /// Pops a given number of screens off the stack.
+  /// - Parameter count: The number of screens to go back. Defaults to 1.
+  mutating func pop(_ count: Int = 1) {
+    elements.pop(count)
+  }
+
+  /// Pops to a given index in the array of screens. The resulting screen count
+  /// will be index.
+  /// - Parameter index: The index that should become top of the stack.
+  mutating func popTo(index: Int) {
+    elements.popTo(index: index)
+  }
+
+  /// Pops to the root screen (index 0). The resulting screen count
+  /// will be 1.
+  mutating func popToRoot() {
+    elements.popToRoot()
+  }
+
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// that satisfies the given condition. If no screens satisfy the condition,
+  /// the screens array will be unchanged.
+  /// - Parameter condition: The predicate indicating which screen to pop to.
+  /// - Returns: A `Bool` indicating whether a screen was found.
+  @discardableResult
+  mutating func popTo(where condition: (AnyHashable) -> Bool) -> Bool {
+    elements.popTo(where: condition)
+  }
+}
+
+public extension NBNavigationPath {
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// equal to the given screen. If no screens are found,
+  /// the screens array will be unchanged.
+  /// - Parameter screen: The predicate indicating which screen to go back to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  mutating func popTo(_ screen: AnyHashable) -> Bool {
+    return elements.popTo(screen)
+  }
+}

--- a/Sources/NavigationBackport/NBNavigationStack.swift
+++ b/Sources/NavigationBackport/NBNavigationStack.swift
@@ -29,10 +29,11 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
   public var body: some View {
     NavigationView {
       Router(rootView: root, screens: path)
-        .environmentObject(NavigationPathHolder(erasedPath))
-        .environmentObject(destinationBuilder)
-        .environmentObject(Navigator(path))
-    }.navigationViewStyle(supportedNavigationViewStyle)
+    }
+    .navigationViewStyle(supportedNavigationViewStyle)
+    .environmentObject(NavigationPathHolder(erasedPath))
+    .environmentObject(destinationBuilder)
+    .environmentObject(Navigator(path))
   }
 
   public init(path: Binding<[Data]>?, @ViewBuilder root: () -> Root) {

--- a/Sources/NavigationBackport/NBNavigationStack.swift
+++ b/Sources/NavigationBackport/NBNavigationStack.swift
@@ -7,7 +7,7 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
   @State var ownedPath: [Data] = []
   @StateObject var destinationBuilder = DestinationBuilderHolder()
   var root: Root
-  
+
   var path: Binding<[Data]> {
     unownedPath ?? $ownedPath
   }
@@ -31,11 +31,12 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
       Router(rootView: root, screens: path)
         .environmentObject(NavigationPathHolder(erasedPath))
         .environmentObject(destinationBuilder)
+        .environmentObject(Navigator(path))
     }.navigationViewStyle(supportedNavigationViewStyle)
   }
 
   public init(path: Binding<[Data]>?, @ViewBuilder root: () -> Root) {
-    self.unownedPath = path
+    unownedPath = path
     self.root = root()
   }
 }

--- a/Sources/NavigationBackport/NBScreen.swift
+++ b/Sources/NavigationBackport/NBScreen.swift
@@ -1,0 +1,5 @@
+/// An empty protocol extending Hashable. Allows access to utility extensions on Array where the element
+/// conforms to NBScreen, rather than polluting all Arrays with navigation APIs.
+public protocol NBScreen: Hashable {}
+
+extension AnyHashable: NBScreen {}

--- a/Sources/NavigationBackport/Navigator+utilities.swift
+++ b/Sources/NavigationBackport/Navigator+utilities.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public extension Navigator where Screen: NBScreen {
+  /// Pushes a new screen via a push navigation.
+  /// - Parameter screen: The screen to push.
+  func push(_ screen: Screen) {
+    path.push(screen)
+  }
+  
+  /// Pops a given number of screens off the stack.
+  /// - Parameter count: The number of screens to go back. Defaults to 1.
+  func pop(_ count: Int = 1) {
+    path.pop(count)
+  }
+
+  /// Pops to a given index in the array of screens. The resulting screen count
+  /// will be index.
+  /// - Parameter index: The index that should become top of the stack.
+  func popTo(index: Int) {
+    path.popTo(index: index)
+  }
+
+  /// Pops to the root screen (index 0). The resulting screen count
+  /// will be 1.
+  func popToRoot() {
+    path.popToRoot()
+  }
+
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// that satisfies the given condition. If no screens satisfy the condition,
+  /// the screens array will be unchanged.
+  /// - Parameter condition: The predicate indicating which screen to pop to.
+  /// - Returns: A `Bool` indicating whether a screen was found.
+  @discardableResult
+  func popTo(where condition: (Screen) -> Bool) -> Bool {
+    path.popTo(where: condition)
+  }
+}
+
+public extension Navigator where Screen: NBScreen & Equatable {
+  /// Pops to the topmost (most recently pushed) screen in the stack
+  /// equal to the given screen. If no screens are found,
+  /// the screens array will be unchanged.
+  /// - Parameter screen: The predicate indicating which screen to go back to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  func popTo(_ screen: Screen) -> Bool {
+    return path.popTo(screen)
+  }
+}
+
+public extension Navigator where Screen: NBScreen & Identifiable {
+  /// Pops to the topmost (most recently pushed) identifiable screen in the stack
+  /// with the given ID. If no screens are found, the screens array will be unchanged.
+  /// - Parameter id: The id of the screen to goBack to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  func popTo(id: Screen.ID) -> Bool {
+    path.popTo(id: id)
+  }
+}

--- a/Sources/NavigationBackport/Navigator+utilities.swift
+++ b/Sources/NavigationBackport/Navigator+utilities.swift
@@ -59,3 +59,14 @@ public extension Navigator where Screen: NBScreen & Identifiable {
     path.popTo(id: id)
   }
 }
+
+public extension Navigator where Screen == AnyHashable {
+  /// Pops to the topmost (most recently pushed) identifiable screen in the stack
+  /// with the given ID. If no screens are found, the screens array will be unchanged.
+  /// - Parameter id: The id of the screen to goBack to.
+  /// - Returns: A `Bool` indicating whether a matching screen was found.
+  @discardableResult
+  func popTo<T: Hashable>(_ screenType: T.Type) -> Bool {
+    popTo(where: { $0 is T })
+  }
+}

--- a/Sources/NavigationBackport/Navigator.swift
+++ b/Sources/NavigationBackport/Navigator.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+public typealias PathNavigator = Navigator<AnyHashable>
+
+/// An object available via the environment that gives access to the current path.
+/// Supports push and pop operations when `Screen` conforms to `NBScreen`.
+@MainActor
+public class Navigator<Screen>: ObservableObject {
+  private let pathBinding: Binding<[Screen]>
+
+  /// The current navigation path.
+  public var path: [Screen] {
+    get { pathBinding.wrappedValue }
+    set { pathBinding.wrappedValue = newValue }
+  }
+
+  init(_ pathBinding: Binding<[Screen]>) {
+    self.pathBinding = pathBinding
+  }
+
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
+  @_disfavoredOverload
+  public func withDelaysIfUnsupported(transform: (inout [Screen]) -> Void, onCompletion: (() -> Void)? = nil) {
+    let start = path
+    let end = apply(transform, to: start)
+    Task { @MainActor in
+      await pathBinding.withDelaysIfUnsupported(from: start, to: end, keyPath: \.self)
+      onCompletion?()
+    }
+  }
+
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
+  @MainActor
+  public func withDelaysIfUnsupported(transform: (inout [Screen]) -> Void) async {
+    await pathBinding.withDelaysIfUnsupported(transform)
+  }
+}

--- a/Sources/NavigationBackport/Node.swift
+++ b/Sources/NavigationBackport/Node.swift
@@ -7,10 +7,6 @@ struct Node<Screen>: View {
   let index: Int
   let screen: Screen?
 
-  @EnvironmentObject var pathHolder: NavigationPathHolder
-  @EnvironmentObject var navigator: Navigator<Screen>
-  @EnvironmentObject var destinationBuilder: DestinationBuilderHolder
-
   init(allScreens: [Screen], truncateToIndex: @escaping (Int) -> Void, index: Int) {
     self.allScreens = allScreens
     self.truncateToIndex = truncateToIndex
@@ -31,9 +27,6 @@ struct Node<Screen>: View {
 
   var next: some View {
     Node(allScreens: allScreens, truncateToIndex: truncateToIndex, index: index + 1)
-      .environmentObject(pathHolder)
-      .environmentObject(destinationBuilder)
-      .environmentObject(navigator)
   }
 
   var body: some View {

--- a/Sources/NavigationBackport/Node.swift
+++ b/Sources/NavigationBackport/Node.swift
@@ -8,13 +8,14 @@ struct Node<Screen>: View {
   let screen: Screen?
 
   @EnvironmentObject var pathHolder: NavigationPathHolder
+  @EnvironmentObject var navigator: Navigator<Screen>
   @EnvironmentObject var destinationBuilder: DestinationBuilderHolder
 
   init(allScreens: [Screen], truncateToIndex: @escaping (Int) -> Void, index: Int) {
     self.allScreens = allScreens
     self.truncateToIndex = truncateToIndex
     self.index = index
-    self.screen = allScreens[safe: index]
+    screen = allScreens[safe: index]
   }
 
   private var isActiveBinding: Binding<Bool> {
@@ -32,6 +33,7 @@ struct Node<Screen>: View {
     Node(allScreens: allScreens, truncateToIndex: truncateToIndex, index: index + 1)
       .environmentObject(pathHolder)
       .environmentObject(destinationBuilder)
+      .environmentObject(navigator)
   }
 
   var body: some View {

--- a/Sources/NavigationBackport/ObservableObject+withDelaysIfUnsupported.swift
+++ b/Sources/NavigationBackport/ObservableObject+withDelaysIfUnsupported.swift
@@ -1,13 +1,12 @@
 import Foundation
 import SwiftUI
 
-extension ObservableObject {
-  
+public extension ObservableObject {
   /// Any changes can be made to the screens array passed to the transform closure. If those
   /// changes are not supported within a single update by SwiftUI, the changes will be
   /// applied in stages. An async version of this function is also available.
   @_disfavoredOverload
-  public func withDelaysIfUnsupported<Screen>(_ keyPath: WritableKeyPath<Self, [Screen]>, transform: (inout [Screen]) -> Void, onCompletion: (() -> Void)? = nil) {
+  func withDelaysIfUnsupported<Screen>(_ keyPath: WritableKeyPath<Self, [Screen]>, transform: (inout [Screen]) -> Void, onCompletion: (() -> Void)? = nil) {
     let start = self[keyPath: keyPath]
     let end = apply(transform, to: start)
     Task { @MainActor in
@@ -15,17 +14,40 @@ extension ObservableObject {
       onCompletion?()
     }
   }
-  
+
   /// Any changes can be made to the screens array passed to the transform closure. If those
   /// changes are not supported within a single update by SwiftUI, the changes will be
   /// applied in stages.
   @MainActor
-  public func withDelaysIfUnsupported<Screen>(_ keyPath: WritableKeyPath<Self, [Screen]>, transform: (inout [Screen]) -> Void) async {
+  func withDelaysIfUnsupported<Screen>(_ keyPath: WritableKeyPath<Self, [Screen]>, transform: (inout [Screen]) -> Void) async {
     let start = self[keyPath: keyPath]
     let end = apply(transform, to: start)
     await withDelaysIfUnsupported(keyPath, from: start, to: end)
   }
-  
+
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages. An async version of this function is also available.
+  @_disfavoredOverload
+  func withDelaysIfUnsupported(_ keyPath: WritableKeyPath<Self, NBNavigationPath>, transform: (inout NBNavigationPath) -> Void, onCompletion: (() -> Void)? = nil) {
+    let start = self[keyPath: keyPath]
+    let end = apply(transform, to: start)
+    Task { @MainActor in
+      await withDelaysIfUnsupported(keyPath.appending(path: \.elements), from: start.elements, to: end.elements)
+      onCompletion?()
+    }
+  }
+
+  /// Any changes can be made to the screens array passed to the transform closure. If those
+  /// changes are not supported within a single update by SwiftUI, the changes will be
+  /// applied in stages.
+  @MainActor
+  func withDelaysIfUnsupported(_ keyPath: WritableKeyPath<Self, NBNavigationPath>, transform: (inout NBNavigationPath) -> Void) async {
+    let start = self[keyPath: keyPath]
+    let end = apply(transform, to: start)
+    await withDelaysIfUnsupported(keyPath.appending(path: \.elements), from: start.elements, to: end.elements)
+  }
+
   @MainActor
   fileprivate func withDelaysIfUnsupported<Screen>(_ keyPath: WritableKeyPath<Self, [Screen]>, from start: [Screen], to end: [Screen]) async {
     let binding = Binding(

--- a/Sources/NavigationBackport/Router.swift
+++ b/Sources/NavigationBackport/Router.swift
@@ -5,9 +5,6 @@ struct Router<Screen, RootView: View>: View {
   let rootView: RootView
 
   @Binding var screens: [Screen]
-  @EnvironmentObject var navigator: Navigator<Screen>
-  @EnvironmentObject var pathHolder: NavigationPathHolder
-  @EnvironmentObject var destinationBuilder: DestinationBuilderHolder
 
   init(rootView: RootView, screens: Binding<[Screen]>) {
     self.rootView = rootView
@@ -16,9 +13,6 @@ struct Router<Screen, RootView: View>: View {
 
   var pushedScreens: some View {
     Node(allScreens: screens, truncateToIndex: { screens = Array(screens.prefix($0)) }, index: 0)
-      .environmentObject(pathHolder)
-      .environmentObject(destinationBuilder)
-      .environmentObject(navigator)
   }
 
   private var isActiveBinding: Binding<Bool> {

--- a/Sources/NavigationBackport/Router.swift
+++ b/Sources/NavigationBackport/Router.swift
@@ -1,22 +1,24 @@
 import Foundation
 import SwiftUI
 
-public struct Router<Screen, RootView: View>: View {
+struct Router<Screen, RootView: View>: View {
   let rootView: RootView
 
   @Binding var screens: [Screen]
+  @EnvironmentObject var navigator: Navigator<Screen>
   @EnvironmentObject var pathHolder: NavigationPathHolder
   @EnvironmentObject var destinationBuilder: DestinationBuilderHolder
 
-  public init(rootView: RootView, screens: Binding<[Screen]>) {
+  init(rootView: RootView, screens: Binding<[Screen]>) {
     self.rootView = rootView
-    self._screens = screens
+    _screens = screens
   }
 
   var pushedScreens: some View {
     Node(allScreens: screens, truncateToIndex: { screens = Array(screens.prefix($0)) }, index: 0)
       .environmentObject(pathHolder)
       .environmentObject(destinationBuilder)
+      .environmentObject(navigator)
   }
 
   private var isActiveBinding: Binding<Bool> {
@@ -30,7 +32,7 @@ public struct Router<Screen, RootView: View>: View {
     )
   }
 
-  public var body: some View {
+  var body: some View {
     rootView
       .background(
         NavigationLink(destination: pushedScreens, isActive: isActiveBinding, label: EmptyView.init)

--- a/Sources/NavigationBackport/apply.swift
+++ b/Sources/NavigationBackport/apply.swift
@@ -1,0 +1,5 @@
+func apply<T>(_ transform: (inout T) -> Void, to input: T) -> T {
+  var transformed = input
+  transform(&transformed)
+  return transformed
+}


### PR DESCRIPTION
This PR:

- Adds a `Navigator` object accessible via the environment, which gives access to the current navigation path.
- Adds utilities for pushing and popping via the navigator, or directly with an Array or NBNavigationPath.

## Usage:
The navigator can be accessed via the environment, e.g. for a NBNavigationPath-backed stack:

`@EnvironmentObject var navigator: PathNavigator`

Or for an Array-backed stack:

`@EnvironmentObject var navigator: Navigator<Screen>`

The navigator can then be used in a variety of ways:

```swift
navigator.push(Profile(name: "John"))

navigator.pop()

navigator.popToRoot()

navigator.popTo(Profile.self)
```