### PR TITLE
Add NBNavigationSplitView

### DIFF
--- a/NavigationBackportApp/NavigationBackportApp.xcodeproj/project.pbxproj
+++ b/NavigationBackportApp/NavigationBackportApp.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		52925EC228549A62001B9190 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52925EB028549A60001B9190 /* ContentView.swift */; };
 		52925EC328549A62001B9190 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52925EB128549A62001B9190 /* Assets.xcassets */; };
 		52925EC428549A62001B9190 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52925EB128549A62001B9190 /* Assets.xcassets */; };
-		52925ECF28549A84001B9190 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 52925ECE28549A84001B9190 /* NavigationBackport */; };
 		529673CE286BB44400C01BCF /* NBNavigationPathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673CD286BB44400C01BCF /* NBNavigationPathView.swift */; };
 		529673CF286BB44400C01BCF /* NBNavigationPathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673CD286BB44400C01BCF /* NBNavigationPathView.swift */; };
 		529673D1286BB50200C01BCF /* ArrayBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D0286BB50200C01BCF /* ArrayBindingView.swift */; };
@@ -21,6 +20,12 @@
 		529673D4286BC48600C01BCF /* NoBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D3286BC48600C01BCF /* NoBindingView.swift */; };
 		529673D5286BC48600C01BCF /* NoBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529673D3286BC48600C01BCF /* NoBindingView.swift */; };
 		52DD85F82895C984004B5344 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 52DD85F72895C984004B5344 /* NavigationBackport */; };
+		5A70FAF42886436C001F26D1 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 5A70FAF32886436C001F26D1 /* NavigationBackport */; };
+		5A70FAF628864370001F26D1 /* NavigationBackport in Frameworks */ = {isa = PBXBuildFile; productRef = 5A70FAF528864370001F26D1 /* NavigationBackport */; };
+		5ABA56EB288282C500178824 /* SplitDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E8288282C400178824 /* SplitDemo.swift */; };
+		5ABA56EC288282C500178824 /* SplitDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56E8288282C400178824 /* SplitDemo.swift */; };
+		5ABA56EF288282C500178824 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56EA288282C500178824 /* SidebarView.swift */; };
+		5ABA56F0288282C500178824 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABA56EA288282C500178824 /* SidebarView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +39,8 @@
 		529673CD286BB44400C01BCF /* NBNavigationPathView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NBNavigationPathView.swift; sourceTree = "<group>"; };
 		529673D0286BB50200C01BCF /* ArrayBindingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayBindingView.swift; sourceTree = "<group>"; };
 		529673D3286BC48600C01BCF /* NoBindingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoBindingView.swift; sourceTree = "<group>"; };
+		5ABA56E8288282C400178824 /* SplitDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplitDemo.swift; sourceTree = "<group>"; };
+		5ABA56EA288282C500178824 /* SidebarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -41,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52925ECF28549A84001B9190 /* NavigationBackport in Frameworks */,
+				5A70FAF42886436C001F26D1 /* NavigationBackport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -50,6 +57,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				52DD85F82895C984004B5344 /* NavigationBackport in Frameworks */,
+				5A70FAF628864370001F26D1 /* NavigationBackport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,13 +71,15 @@
 				52925EAE28549A60001B9190 /* Shared */,
 				52925EBD28549A62001B9190 /* macOS */,
 				52925EB728549A62001B9190 /* Products */,
-				52DD85F62895C984004B5344 /* Frameworks */,
+				5A70FAF22886436C001F26D1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
 		52925EAE28549A60001B9190 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				5ABA56EA288282C500178824 /* SidebarView.swift */,
+				5ABA56E8288282C400178824 /* SplitDemo.swift */,
 				52925EAF28549A60001B9190 /* NavigationBackportApp.swift */,
 				52925EB028549A60001B9190 /* ContentView.swift */,
 				529673D0286BB50200C01BCF /* ArrayBindingView.swift */,
@@ -105,7 +115,7 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
-		52DD85F62895C984004B5344 /* Frameworks */ = {
+		5A70FAF22886436C001F26D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -129,7 +139,7 @@
 			);
 			name = "NavigationBackportApp (iOS)";
 			packageProductDependencies = (
-				52925ECE28549A84001B9190 /* NavigationBackport */,
+				5A70FAF32886436C001F26D1 /* NavigationBackport */,
 			);
 			productName = "NavigationBackportApp (iOS)";
 			productReference = 52925EB628549A62001B9190 /* NavigationBackportApp.app */;
@@ -150,6 +160,7 @@
 			name = "NavigationBackportApp (macOS)";
 			packageProductDependencies = (
 				52DD85F72895C984004B5344 /* NavigationBackport */,
+				5A70FAF528864370001F26D1 /* NavigationBackport */,
 			);
 			productName = "NavigationBackportApp (macOS)";
 			productReference = 52925EBC28549A62001B9190 /* NavigationBackportApp.app */;
@@ -183,7 +194,6 @@
 			);
 			mainGroup = 52925EA928549A60001B9190;
 			packageReferences = (
-				52925ECD28549A84001B9190 /* XCRemoteSwiftPackageReference "NavigationBackport" */,
 			);
 			productRefGroup = 52925EB728549A62001B9190 /* Products */;
 			projectDirPath = "";
@@ -220,6 +230,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				529673CE286BB44400C01BCF /* NBNavigationPathView.swift in Sources */,
+				5ABA56EF288282C500178824 /* SidebarView.swift in Sources */,
+				5ABA56EB288282C500178824 /* SplitDemo.swift in Sources */,
 				529673D1286BB50200C01BCF /* ArrayBindingView.swift in Sources */,
 				529673D4286BC48600C01BCF /* NoBindingView.swift in Sources */,
 				52925EC128549A62001B9190 /* ContentView.swift in Sources */,
@@ -232,6 +244,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				529673CF286BB44400C01BCF /* NBNavigationPathView.swift in Sources */,
+				5ABA56F0288282C500178824 /* SidebarView.swift in Sources */,
+				5ABA56EC288282C500178824 /* SplitDemo.swift in Sources */,
 				529673D2286BB50200C01BCF /* ArrayBindingView.swift in Sources */,
 				529673D5286BC48600C01BCF /* NoBindingView.swift in Sources */,
 				52925EC228549A62001B9190 /* ContentView.swift in Sources */,
@@ -377,6 +391,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.uk.johnpatrickmorgan.NavigationBackportApp;
 				PRODUCT_NAME = NavigationBackportApp;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -407,6 +424,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.uk.johnpatrickmorgan.NavigationBackportApp;
 				PRODUCT_NAME = NavigationBackportApp;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -504,24 +524,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		52925ECD28549A84001B9190 /* XCRemoteSwiftPackageReference "NavigationBackport" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/johnpatrickmorgan/NavigationBackport";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		52925ECE28549A84001B9190 /* NavigationBackport */ = {
+		52DD85F72895C984004B5344 /* NavigationBackport */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 52925ECD28549A84001B9190 /* XCRemoteSwiftPackageReference "NavigationBackport" */;
 			productName = NavigationBackport;
 		};
-		52DD85F72895C984004B5344 /* NavigationBackport */ = {
+		5A70FAF32886436C001F26D1 /* NavigationBackport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NavigationBackport;
+		};
+		5A70FAF528864370001F26D1 /* NavigationBackport */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NavigationBackport;
 		};

--- a/NavigationBackportApp/Shared/ContentView.swift
+++ b/NavigationBackportApp/Shared/ContentView.swift
@@ -23,6 +23,10 @@ struct ContentView: View {
         .tabItem { Text("ArrayBinding") }
       NoBindingView()
         .tabItem { Text("NoBinding") }
+      if UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.userInterfaceIdiom == .mac {
+        SplitDemo()
+          .tabItem { Text("SplitDemo") }
+      }
     }
   }
 }

--- a/NavigationBackportApp/Shared/ContentView.swift
+++ b/NavigationBackportApp/Shared/ContentView.swift
@@ -23,10 +23,15 @@ struct ContentView: View {
         .tabItem { Text("ArrayBinding") }
       NoBindingView()
         .tabItem { Text("NoBinding") }
-      if UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.userInterfaceIdiom == .mac {
+      #if os(macOS)
         SplitDemo()
           .tabItem { Text("SplitDemo") }
-      }
+      #else
+        if UIDevice.current.userInterfaceIdiom == .pad || UIDevice.current.userInterfaceIdiom == .mac {
+          SplitDemo()
+            .tabItem { Text("SplitDemo") }
+        }
+      #endif
     }
   }
 }

--- a/NavigationBackportApp/Shared/SidebarView.swift
+++ b/NavigationBackportApp/Shared/SidebarView.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+
+struct SidebarView: View {
+  @Binding var selectedBindingType: BindingType?
+
+  var body: some View {
+    if #available(iOS 16.0, *) {
+      List(selection: $selectedBindingType) {
+        ForEach(BindingType.allCases, id: \.self) { bindingType in
+          Text(bindingType.rawValue)
+        }
+      }
+    } else {
+      List(selection: $selectedBindingType) {
+        ForEach(BindingType.allCases, id: \.self) { bindingType in
+          Button {
+            selectedBindingType = bindingType
+          } label: {
+            HStack {
+              Text(bindingType.rawValue)
+              Spacer()
+            }
+            .padding()
+            .background(bindingType == selectedBindingType ? Color.gray.opacity(0.5) : Color.clear)
+            .cornerRadius(10)
+            .contentShape(Rectangle())
+          }
+        }
+        .buttonStyle(.plain)
+      }
+    }
+  }
+}

--- a/NavigationBackportApp/Shared/SplitDemo.swift
+++ b/NavigationBackportApp/Shared/SplitDemo.swift
@@ -1,0 +1,31 @@
+import Foundation
+import NavigationBackport
+import SwiftUI
+
+enum BindingType: String, CaseIterable, Hashable {
+  case array
+  case path
+  case noBinding
+}
+
+struct SplitDemo: View {
+  @State var selectedBindingType: BindingType?
+
+  var body: some View {
+    VStack {
+      NBNavigationSplitView {
+        SidebarView(selectedBindingType: $selectedBindingType)
+      } detail: {
+        if selectedBindingType == .path {
+          NBNavigationPathView()
+        } else if selectedBindingType == .array {
+          ArrayBindingView()
+        } else if selectedBindingType == .noBinding {
+          NoBindingView()
+        } else {
+          Text("Select a binding type").foregroundColor(Color.gray)
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This package uses the navigation APIs available in older SwiftUI versions (such 
 
 ✅ `NavigationPath.CodableRepresentation` -> `NBNavigationPath.CodableRepresentation`
 
+✳️ `NavigationSplitView` -> `NBNavigationSplitView` ([with limitations](#limitations-of-nbnavigationsplitview)
+
 
 You can migrate to these APIs now, and when you eventually bump your deployment target to iOS 16, you can remove this library and easily migrate to its SwiftUI equivalent. `NavigationStack`'s full API is replicated, so you can initialise an `NBNavigationStack` with a binding to an `Array`, with a binding to a `NBNavigationPath` binding, or with no binding at all.
 
@@ -166,3 +168,7 @@ You can make any changes to the path passed into the `withDelaysIfUnsupported` c
 ## Support for iOS/tvOS 13
 
 This library targets iOS/tvOS versions 14 and above, since it uses `StateObject`, which is unavailable on iOS/tvOS 13. However, there is an `ios13` branch, which uses [SwiftUIBackports](https://github.com/shaps80/SwiftUIBackports)' backported StateObject, so that it works on iOS/tvOS 13 too.
+
+## Limitations of NBNavigationSplitView
+
+Some APIs related to column customisation are not available as they are not possible to backport using SwiftUI's older navigation APIs: e.g., `columnVisibility`, `navigationSplitViewColumnWidth` and `navigationSplitViewStyle`. Additionally, while it's possible to nest an `NBNavigationStack` within a `NBNavigationSplitView`, it should only be nested within the detail pane of the split view. Otherwise, sidebar and content screens might leak into the next pane.

--- a/Sources/NavigationBackport/DestinationBuilderHolder.swift
+++ b/Sources/NavigationBackport/DestinationBuilderHolder.swift
@@ -48,6 +48,6 @@ class DestinationBuilderHolder: ObservableObject {
       return output
     }
     assertionFailure("No view builder found for key \(key)")
-    return AnyView(Image(systemName: "exclamationmark.triangle"))
+    return AnyView(ErrorView(text: "No view builder found for key \(key)"))
   }
 }

--- a/Sources/NavigationBackport/ErrorView.swift
+++ b/Sources/NavigationBackport/ErrorView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ErrorView: View {
+  let text: String
+
+  var body: some View {
+    VStack(spacing: 8) {
+      Image(systemName: "exclamationmark.triangle")
+      Text(text)
+    }
+  }
+}

--- a/Sources/NavigationBackport/NBNavigationSplitView.swift
+++ b/Sources/NavigationBackport/NBNavigationSplitView.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftUI
+
+@available(iOS, deprecated: 16.0, message: "Use SwiftUI's Navigation API beyond iOS 15")
+public struct NBNavigationSplitView<Sidebar: View, Content: View, Detail: View>: View {
+  let sideBar: Sidebar
+  let content: Content?
+  let detail: Detail
+
+  public var body: some View {
+    if let content {
+      NavigationView {
+        sideBar
+          .environment(\.splitViewPane, .sideBar)
+        content
+          .environment(\.splitViewPane, .content)
+        detail
+          .environment(\.splitViewPane, .detail)
+      }
+    } else {
+      NavigationView {
+        sideBar
+          .environment(\.splitViewPane, .sideBar)
+        detail
+          .environment(\.splitViewPane, .detail)
+      }
+    }
+  }
+
+  public init(@ViewBuilder sideBar: () -> Sidebar, @ViewBuilder content: () -> Content, @ViewBuilder detail: () -> Detail) {
+    self.sideBar = sideBar()
+    self.content = content()
+    self.detail = detail()
+  }
+}
+
+public extension NBNavigationSplitView where Content == EmptyView {
+  init(@ViewBuilder sideBar: () -> Sidebar, @ViewBuilder detail: () -> Detail) {
+    self.sideBar = sideBar()
+    self.content = nil
+    self.detail = detail()
+  }
+}

--- a/Sources/NavigationBackport/NBNavigationStack.swift
+++ b/Sources/NavigationBackport/NBNavigationStack.swift
@@ -30,7 +30,8 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
     } else {
       if let splitViewPane {
         let _ = assertionFailure("""
-          NBNavigationStack should only be embedded in the detail pane of an NBNavigationSplitView, not the \(splitViewPane) pane.
+          NBNavigationStack should only be embedded in the detail pane of an NBNavigationSplitView, not the \
+          \(splitViewPane) pane. This is a limitation of NBNavigationSplitView compared to NavigationSplitView.
           """
         )
       }

--- a/Sources/NavigationBackport/Node.swift
+++ b/Sources/NavigationBackport/Node.swift
@@ -2,12 +2,17 @@ import Foundation
 import SwiftUI
 
 struct Node<Screen>: View {
-  let allScreens: [Screen]
+  let allScreens: [AnyHashable]
   let truncateToIndex: (Int) -> Void
   let index: Int
-  let screen: Screen?
+  let screen: AnyHashable?
 
-  init(allScreens: [Screen], truncateToIndex: @escaping (Int) -> Void, index: Int) {
+  @EnvironmentObject var pathHolder: NavigationPathHolder
+  @EnvironmentObject var navigator: Navigator<Screen>
+  @EnvironmentObject var destinationBuilder: DestinationBuilderHolder
+  @EnvironmentObject var pathAppender: PathAppender
+
+  init(allScreens: [AnyHashable], truncateToIndex: @escaping (Int) -> Void, index: Int) {
     self.allScreens = allScreens
     self.truncateToIndex = truncateToIndex
     self.index = index
@@ -26,7 +31,11 @@ struct Node<Screen>: View {
   }
 
   var next: some View {
-    Node(allScreens: allScreens, truncateToIndex: truncateToIndex, index: index + 1)
+    Node<Screen>(allScreens: allScreens, truncateToIndex: truncateToIndex, index: index + 1)
+      .environmentObject(pathHolder)
+      .environmentObject(destinationBuilder)
+      .environmentObject(navigator)
+      .environmentObject(pathAppender)
   }
 
   var body: some View {

--- a/Sources/NavigationBackport/Router.swift
+++ b/Sources/NavigationBackport/Router.swift
@@ -4,15 +4,23 @@ import SwiftUI
 struct Router<Screen, RootView: View>: View {
   let rootView: RootView
 
-  @Binding var screens: [Screen]
+  @Binding var screens: [AnyHashable]
+  @EnvironmentObject var navigator: Navigator<Screen>
+  @EnvironmentObject var pathHolder: NavigationPathHolder
+  @EnvironmentObject var destinationBuilder: DestinationBuilderHolder
+  @EnvironmentObject var pathAppender: PathAppender
 
-  init(rootView: RootView, screens: Binding<[Screen]>) {
+  init(rootView: RootView, screens: Binding<[AnyHashable]>, screenType: Screen.Type) {
     self.rootView = rootView
     _screens = screens
   }
 
   var pushedScreens: some View {
-    Node(allScreens: screens, truncateToIndex: { screens = Array(screens.prefix($0)) }, index: 0)
+    Node<Screen>(allScreens: screens, truncateToIndex: { screens = Array(screens.prefix($0)) }, index: 0)
+      .environmentObject(pathHolder)
+      .environmentObject(destinationBuilder)
+      .environmentObject(navigator)
+      .environmentObject(pathAppender)
   }
 
   private var isActiveBinding: Binding<Bool> {

--- a/Sources/NavigationBackport/SplitViewPane.swift
+++ b/Sources/NavigationBackport/SplitViewPane.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+enum SplitViewPane: String {
+  case sideBar
+  case content
+  case detail
+}
+
+private struct SplitViewPaneKey: EnvironmentKey {
+  static let defaultValue: SplitViewPane? = nil
+}
+
+extension EnvironmentValues {
+  var splitViewPane: SplitViewPane? {
+    get { self[SplitViewPaneKey.self] }
+    set { self[SplitViewPaneKey.self] = newValue }
+  }
+}

--- a/Tests/NavigationBackportTests/NavigationBackportTests.swift
+++ b/Tests/NavigationBackportTests/NavigationBackportTests.swift
@@ -16,7 +16,7 @@ final class NavigationBackportTests: XCTestCase {
     ]
     XCTAssertEqual(steps, expectedSteps)
   }
-  
+
   func testPopAllInOne() {
     let start = [1, 2, 3, 4]
     let end = [-1]
@@ -26,7 +26,7 @@ final class NavigationBackportTests: XCTestCase {
     let expectedSteps = [end]
     XCTAssertEqual(steps, expectedSteps)
   }
-    
+
   func testEquatableEquals() {
     let path = [1, 2, 3]
     let lhs = NBNavigationPath(path)
@@ -41,5 +41,4 @@ final class NavigationBackportTests: XCTestCase {
 
     XCTAssertNotEqual(lhs, rhs)
   }
-
 }


### PR DESCRIPTION
This PR: 

- Adds `NBNavigationSplitView`, attempting to overcome some limitations of #9.

### Limitations

Some APIs related to column customisation are not available as they are not possible to backport using SwiftUI's older navigation APIs: e.g., `columnVisibility`, `navigationSplitViewColumnWidth` and `navigationSplitViewStyle`. Additionally, while it's possible to nest an `NBNavigationStack` within a `NBNavigationSplitView`, it should only be nested within the _detail_ pane of the split view. Otherwise, sidebar and content screens might leak into the next pane.