### PR TITLE
Bugfix: Support class inheritance

### DIFF
--- a/NavigationBackportApp/Shared/ContentView.swift
+++ b/NavigationBackportApp/Shared/ContentView.swift
@@ -14,6 +14,28 @@ struct NumberList: Hashable, Codable {
   let range: Range<Int>
 }
 
+class ClassDestination {
+    let data: String
+
+    init(data: String) {
+        self.data = data
+    }
+}
+
+extension ClassDestination: Hashable {
+  static func == (lhs: ClassDestination, rhs: ClassDestination) -> Bool {
+    lhs.data == rhs.data
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(data)
+  }
+}
+
+class SampleClassDestination: ClassDestination {
+    init() { super.init(data: "sample data") }
+}
+
 struct ContentView: View {
   var body: some View {
     TabView {

--- a/NavigationBackportApp/Shared/NBNavigationPathView.swift
+++ b/NavigationBackportApp/Shared/NBNavigationPathView.swift
@@ -24,6 +24,9 @@ struct NBNavigationPathView: View {
           .nbNavigationDestination(for: EmojiVisualisation.self, destination: { visualisation in
             EmojiView(visualisation: visualisation)
           })
+          .nbNavigationDestination(for: ClassDestination.self, destination: { destination in
+            ClassDestinationView(destination: destination)
+          })
       }
     }
   }
@@ -56,6 +59,8 @@ private struct HomeView: View {
       NBNavigationLink(value: NumberList(range: 0 ..< 100), label: { Text("Pick a number") })
       // Push via navigator
       Button("99 Red balloons", action: show99RedBalloons)
+      // Push child class via navigator
+      Button("Show ClassDestination", action: showClassDestination)
       // Push via Bool binding
       VStack {
         Text("Push local destination")
@@ -75,6 +80,10 @@ private struct HomeView: View {
       $0.append(99)
       $0.append(EmojiVisualisation(emoji: "🎈", count: 99))
     }
+  }
+
+  func showClassDestination() {
+    navigator.push(SampleClassDestination())
   }
 }
 
@@ -120,5 +129,14 @@ private struct EmojiView: View {
   var body: some View {
     Text(visualisation.text)
       .navigationTitle("Visualise \(visualisation.count)")
+  }
+}
+
+private struct ClassDestinationView: View {
+  let destination: ClassDestination
+
+  var body: some View {
+    Text(destination.data)
+      .navigationTitle("A ClassDestination")
   }
 }

--- a/NavigationBackportApp/Shared/NoBindingView.swift
+++ b/NavigationBackportApp/Shared/NoBindingView.swift
@@ -14,6 +14,9 @@ struct NoBindingView: View {
         .nbNavigationDestination(for: EmojiVisualisation.self, destination: { visualisation in
           EmojiView(visualisation: visualisation)
         })
+        .nbNavigationDestination(for: ClassDestination.self, destination: { destination in
+          ClassDestinationView(destination: destination)
+        })
     }
   }
 }
@@ -28,6 +31,8 @@ private struct HomeView: View {
       NBNavigationLink(value: NumberList(range: 0 ..< 100), label: { Text("Pick a number") })
       // Push via navigator
       Button("99 Red balloons", action: show99RedBalloons)
+      // Push child class via navigator
+      Button("Show ClassDestination", action: showClassDestination)
       // Push via Bool binding
       VStack {
         Text("Push local destination")
@@ -45,6 +50,10 @@ private struct HomeView: View {
       $0.append(99)
       $0.append(EmojiVisualisation(emoji: "🎈", count: 99))
     }
+  }
+
+  func showClassDestination() {
+    navigator.push(SampleClassDestination())
   }
 }
 
@@ -92,5 +101,14 @@ private struct EmojiView: View {
   var body: some View {
     Text(visualisation.text)
       .navigationTitle("Visualise \(visualisation.count)")
+  }
+}
+
+private struct ClassDestinationView: View {
+  let destination: ClassDestination
+
+  var body: some View {
+    Text(destination.data)
+      .navigationTitle("A ClassDestination")
   }
 }

--- a/Sources/NavigationBackport/DestinationBuilderHolder.swift
+++ b/Sources/NavigationBackport/DestinationBuilderHolder.swift
@@ -36,18 +36,24 @@ class DestinationBuilderHolder: ObservableObject {
 
   func build<T>(_ typedData: T) -> AnyView {
     let base = (typedData as? AnyHashable)?.base
-    let type = type(of: base ?? typedData)
-    let key: String
     if let identifier = (base ?? typedData) as? LocalDestinationID {
-      key = identifier.rawValue.uuidString
+      let key = identifier.rawValue.uuidString
+      if let builder = builders[key], let output = builder(typedData) {
+        return output
+      }
+      assertionFailure("No view builder found for type \(key)")
     } else {
-      key = Self.identifier(for: type)
-    }
+      var mirror: Mirror? = Mirror(reflecting: base ?? typedData)
+      while mirror != nil {
+        let key = Self.identifier(for: mirror!.subjectType)
 
-    if let builder = builders[key], let output = builder(typedData) {
-      return output
+        if let builder = builders[key], let output = builder(typedData) {
+          return output
+        }
+        mirror = mirror!.superclassMirror
+      }
+      assertionFailure("No view builder found for type \(type(of: base ?? typedData))")
     }
-    assertionFailure("No view builder found for key \(key)")
     return AnyView(Image(systemName: "exclamationmark.triangle"))
   }
 }


### PR DESCRIPTION
Fixes for missing inherited class support for navigation destination types

The way `build<T>(_ typedData: T) → AnyView` was implemented, it didn't support using classes where the `.navigationDestination()` is triggered off a base class and navigation was happening via a child class. This refactoring uses `Mirror(reflecting:)` to get the type info for the given `typedData`, and if no matching navigation destination factory is found, it tries again for its superclass until either a match is found or there are no more superclasses to check.

This also required me to split out the check for `LocalDestinationID` since that doesn't need to be in the loop and only needs to be checked on `typedData` initially.