### PR TITLE
Add all supported OSes to #available checks

### DIFF
--- a/Sources/NavigationBackport/NavigationWrapper.swift
+++ b/Sources/NavigationBackport/NavigationWrapper.swift
@@ -5,7 +5,7 @@ struct NavigationWrapper<Content: View>: View {
   @Environment(\.useNavigationStack) var useNavigationStack
 
   var body: some View {
-    if #available(iOS 16.0, *), useNavigationStack == .whenAvailable {
+      if #available(iOS 16.0, *, macOS 13.0, *, watchOS 7.0, *, tvOS 14.0, *), useNavigationStack == .whenAvailable {
       return AnyView(NavigationStack { content })
         .environment(\.isWithinNavigationStack, true)
     } else {

--- a/Sources/NavigationBackport/View+_navigationDestination.swift
+++ b/Sources/NavigationBackport/View+_navigationDestination.swift
@@ -6,7 +6,7 @@ struct NavigationLinkModifier<Destination: View>: ViewModifier {
   @Environment(\.isWithinNavigationStack) var isWithinNavigationStack
 
   func body(content: Content) -> some View {
-    if #available(iOS 16.0, *), isWithinNavigationStack {
+    if #available(iOS 16.0, *, macOS 13.0, *, watchOS 7.0, *, tvOS 14.0, *), isWithinNavigationStack {
       AnyView(
         content
           .navigationDestination(isPresented: isActiveBinding, destination: { destination })


### PR DESCRIPTION
This library defines in its `Package.swift` that it supports iOS, macOS, watchOS, and tvOS but (before this PR) wouldn't actually compile for any of those platforms due to the `#available` checks not checking for those platforms