### PR TITLE
Remove need for AnyView in NBNavigationStack

### DIFF
--- a/Sources/NavigationBackport/NBNavigationLink.swift
+++ b/Sources/NavigationBackport/NBNavigationLink.swift
@@ -7,7 +7,7 @@ public struct NBNavigationLink<P: Hashable, Label: View>: View {
   var value: P?
   var label: Label
 
-  @EnvironmentObject var pathAppender: PathAppender
+  @EnvironmentObject var pathHolder: NavigationPathHolder
 
   public init(value: P?, @ViewBuilder label: () -> Label) {
     self.value = value
@@ -20,7 +20,7 @@ public struct NBNavigationLink<P: Hashable, Label: View>: View {
     Button(
       action: {
         guard let value = value else { return }
-        pathAppender.append?(value)
+        pathHolder.path.append(value)
       },
       label: { label }
     )

--- a/Sources/NavigationBackport/NBNavigationStack.swift
+++ b/Sources/NavigationBackport/NBNavigationStack.swift
@@ -7,7 +7,6 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
   @Binding var externalTypedPath: [Data]
   @State var internalTypedPath: [Data] = []
   @StateObject var path: NavigationPathHolder
-  @StateObject var pathAppender = PathAppender()
   @StateObject var destinationBuilder = DestinationBuilderHolder()
   @Environment(\.useNavigationStack) var useNavigationStack
   var root: Root
@@ -21,33 +20,27 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
     }
   }
 
+  @ViewBuilder
   var content: some View {
-    pathAppender.append = { [weak path] newElement in
-      path?.path.append(newElement)
-    }
     if #available(iOS 16.0, *, macOS 13.0, *, watchOS 9.0, *, tvOS 16.0, *), useNavigationStack == .whenAvailable {
-      return AnyView(
-        NavigationStack(path: $path.path) {
-          root
-            .navigationDestination(for: AnyHashable.self, destination: { destinationBuilder.build($0) })
-            .navigationDestination(for: LocalDestinationID.self, destination: { destinationBuilder.build($0) })
-        }
-        .environment(\.isWithinNavigationStack, true)
-      )
-    }
-    return AnyView(
+      NavigationStack(path: $path.path) {
+        root
+          .navigationDestination(for: AnyHashable.self, destination: { destinationBuilder.build($0) })
+          .navigationDestination(for: LocalDestinationID.self, destination: { destinationBuilder.build($0) })
+      }
+      .environment(\.isWithinNavigationStack, true)
+    } else {
       NavigationView {
         Router(rootView: root, screens: $path.path)
       }
       .navigationViewStyle(supportedNavigationViewStyle)
       .environment(\.isWithinNavigationStack, false)
-    )
+    }
   }
 
   public var body: some View {
     content
       .environmentObject(path)
-      .environmentObject(pathAppender)
       .environmentObject(destinationBuilder)
       .environmentObject(Navigator(useInternalTypedPath ? $internalTypedPath : $externalTypedPath))
       .onFirstAppear {

--- a/Sources/NavigationBackport/PathAppender.swift
+++ b/Sources/NavigationBackport/PathAppender.swift
@@ -1,7 +1,0 @@
-import Foundation
-import SwiftUI
-
-/// An object that never publishes changes, but allows appending to an NBNavigationStack's path.
-class PathAppender: ObservableObject {
-  var append: ((AnyHashable) -> Void)?
-}


### PR DESCRIPTION
First of all, thank you for creating this library! It might've saved my day today. While looking at the code I was curious if the `AnyView` wrappers in `NBNavigationStack` could be replaced with `@ViewBuilder` and after playing around with that change for a bit I think they can indeed be removed. Thought that might make for a good first contribution 🙂 

Note: I removed `PathAppender` because I could not immediately see how it was different from accessing the `NavigationPathHolder` directly. If this is a mistake on my part please let me know!