### PR TITLE
Add functionality to disable the use of the navigator

### DIFF
--- a/Sources/NavigationBackport/EnvironmentValues+navigationStack.swift
+++ b/Sources/NavigationBackport/EnvironmentValues+navigationStack.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+struct UseNavigatorKey: EnvironmentKey {
+  static let defaultValue = true
+}
+
 struct UseNavigationStackPolicyKey: EnvironmentKey {
   static let defaultValue = UseNavigationStackPolicy.whenAvailable
 }
@@ -9,6 +13,11 @@ struct IsWithinNavigationStackKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
+  var useNavigator: Bool {
+    get { self[UseNavigatorKey.self] }
+    set { self[UseNavigatorKey.self] = newValue }
+  }
+
   var useNavigationStack: UseNavigationStackPolicy {
     get { self[UseNavigationStackPolicyKey.self] }
     set { self[UseNavigationStackPolicyKey.self] = newValue }

--- a/Sources/NavigationBackport/NBNavigationStack.swift
+++ b/Sources/NavigationBackport/NBNavigationStack.swift
@@ -9,6 +9,7 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
   @StateObject var path: NavigationPathHolder
   @StateObject var destinationBuilder = DestinationBuilderHolder()
   @Environment(\.useNavigationStack) var useNavigationStack
+  @Environment(\.useNavigator) var useNavigator
   // NOTE: Using `Environment(\.scenePhase)` doesn't work if the app uses UIKIt lifecycle events (via AppDelegate/SceneDelegate).
   // We do not need to re-render the view when appIsActive changes, and doing so can cause animation glitches, so it is wrapped
   // in `NonReactiveState`.
@@ -47,7 +48,10 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
       .environmentObject(path)
       .environmentObject(Unobserved(object: path))
       .environmentObject(destinationBuilder)
-      .environmentObject(Navigator(useInternalTypedPath ? $internalTypedPath : $externalTypedPath))
+      .if(useNavigator) { content in
+          content
+              .environmentObject(Navigator(useInternalTypedPath ? $internalTypedPath : $externalTypedPath))
+      }
       .onFirstAppear {
         guard isUsingNavigationView else {
           // Path should already be correct thanks to initialiser.

--- a/Sources/NavigationBackport/View+if.swift
+++ b/Sources/NavigationBackport/View+if.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension View {
+  @ViewBuilder func `if`<Content: View>(_ conditional: Bool, content: (Self) -> Content) -> some View {
+    if conditional {
+      content(self)
+    } else {
+      self
+    }
+  }
+}

--- a/Sources/NavigationBackport/View+nbNavigatorEnabled.swift
+++ b/Sources/NavigationBackport/View+nbNavigatorEnabled.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+public extension View {
+  /// Sets the value to enable or disable the navigator functionality.
+  /// This method allows you to specify whether the navigator feature should be active
+  /// or inactive within the current view's environment. By passing `true`, you enable
+  /// the navigator, granting access to enhanced navigation options. Passing `false`
+  /// will disable this feature.
+  /// - Parameter isEnabled: A Boolean value indicating whether the navigator should be enabled or disabled
+  /// - Returns: A view that reflects the updated navigation environment setting.
+  func nbNavigatorEnabled(_ isEnabled: Bool) -> some View {
+    environment(\.useNavigator, isEnabled)
+  }
+}


### PR DESCRIPTION
First of all, I would like to express my gratitude for creating such a wonderful library. We encountered an issue where the `ViewModel` of a closed screen is not being deinitialized. Through research, we discovered that the problem lies in the use of the `Navigator`, which maintains an array of screens. This issue occurs only when an array of View wrappers is used as the path for `NBNavigationStack`.

In our case, the problem can be resolved by disabling the addition of the Navigator for `NBNavigationStack`. Here is a [link](https://github.com/danyaqq/NavigationBackportLeak) to the project where we reproduced the issue. I would appreciate it if you could take a look at this request or suggest alternative solutions to the problem.