### PR TITLE
Fix path state propagation when using NavigationStack

### DIFF
--- a/Sources/NavigationBackport/NBNavigationStack.swift
+++ b/Sources/NavigationBackport/NBNavigationStack.swift
@@ -69,6 +69,10 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
       }
       .onChange(of: externalTypedPath) { externalTypedPath in
         guard path.path != externalTypedPath.map({ $0 }) else { return }
+        guard isUsingNavigationView else {
+          path.path = externalTypedPath.map { $0 }
+          return
+        }
         guard appIsActive.value else { return }
         path.withDelaysIfUnsupported(\.path) {
           $0 = externalTypedPath
@@ -76,6 +80,10 @@ public struct NBNavigationStack<Root: View, Data: Hashable>: View {
       }
       .onChange(of: internalTypedPath) { internalTypedPath in
         guard path.path != internalTypedPath.map({ $0 }) else { return }
+        guard isUsingNavigationView else {
+          path.path = externalTypedPath.map { $0 }
+          return
+        }
         guard appIsActive.value else { return }
         path.withDelaysIfUnsupported(\.path) {
           $0 = internalTypedPath


### PR DESCRIPTION
This PR builds on the work of @lukbukkit in #61 to ensure path changes from iOS' NavigationStack are propagated to the NBNavigationStack's `path` immediately.

Fixes #57