### PR TITLE
Mark the String initializer of NBNavigationLink as @_disfavoredOverload

### DIFF
--- a/Sources/NavigationBackport/NBNavigationLink.swift
+++ b/Sources/NavigationBackport/NBNavigationLink.swift
@@ -32,7 +32,7 @@ public extension NBNavigationLink where Label == Text {
     self.init(value: value) { Text(titleKey) }
   }
 
-  init<S>(_ title: S, value: P?) where S: StringProtocol {
+  @_disfavoredOverload init<S>(_ title: S, value: P?) where S: StringProtocol {
     self.init(value: value) { Text(title) }
   }
 }


### PR DESCRIPTION
Normally in SwiftUI; NavigationLink, Button, Text, Label etc. always favor the LocalizedStringKey initializer.